### PR TITLE
fix: 패키지 런타임 의존성 명시

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,12 @@ version = attr: baekjoon.__version__
 [options]
 packages=
     baekjoon
+install_requires =
+    tomli
+    tomli-w
+    aiohttp
+    lxml
+    nodriver
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
안녕하세요, 
좋은 프로그램 만들어주셔서 감사합니다.
 
다름이 아니라, 이번에 bojtools를 cli로 쓰려다가 
설치할 때, 필요한 의존성 패키지들이 자동으로 설치되지 않아, 사용자가 수동으로 하나씩 설치해야 하는 문제가 있더라구요.

```
$ pip install bojtools
Successfully installed bojtools-0.5.4

$ boj init
ModuleNotFoundError: No module named 'lxml'

$ pip install lxml
$ boj init
ModuleNotFoundError: No module named 'nodriver'

$ pip install nodriver
$ boj init
ModuleNotFoundError: No module named 'tomli_w'
```

사용자가 lxml, nodriver, tomli_w, aiohttp, tomli 등을 일일이 수동으로 설치해야 하는 불편함이 있습니다.

setup.cfg 파일에 install_requires 항목이 누락되어 있어, pip이 패키지 설치 시 런타임 의존성을 자동으로 함께 설치하지 못하는 것 같기에 setup.cfg의 install_requires에 별도로 명시하는 것을 제안드립니다. 

### 추가한 것
setup.cfg에 install_requires 섹션을 추가하여 런타임 의존성을 명시했습니다.
괜찮으시면 반영하셔도 될 것 같습니다. 